### PR TITLE
Add MetricsPipeline.Core library

### DIFF
--- a/IdealComputingMachine.sln
+++ b/IdealComputingMachine.sln
@@ -5,18 +5,44 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DirectorySyncWorker", "DirectorySyncWorker\DirectorySyncWorker.csproj", "{B4DF1190-086C-4C08-8731-7291BEF925B4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MetricsPipeline.Core", "MetricsPipeline.Core\MetricsPipeline.Core.csproj", "{4762DF61-F3B7-49DB-BB7B-E8D86A350B39}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{B4DF1190-086C-4C08-8731-7291BEF925B4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B4DF1190-086C-4C08-8731-7291BEF925B4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B4DF1190-086C-4C08-8731-7291BEF925B4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B4DF1190-086C-4C08-8731-7291BEF925B4}.Debug|x64.Build.0 = Debug|Any CPU
+		{B4DF1190-086C-4C08-8731-7291BEF925B4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B4DF1190-086C-4C08-8731-7291BEF925B4}.Debug|x86.Build.0 = Debug|Any CPU
 		{B4DF1190-086C-4C08-8731-7291BEF925B4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B4DF1190-086C-4C08-8731-7291BEF925B4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B4DF1190-086C-4C08-8731-7291BEF925B4}.Release|x64.ActiveCfg = Release|Any CPU
+		{B4DF1190-086C-4C08-8731-7291BEF925B4}.Release|x64.Build.0 = Release|Any CPU
+		{B4DF1190-086C-4C08-8731-7291BEF925B4}.Release|x86.ActiveCfg = Release|Any CPU
+		{B4DF1190-086C-4C08-8731-7291BEF925B4}.Release|x86.Build.0 = Release|Any CPU
+		{4762DF61-F3B7-49DB-BB7B-E8D86A350B39}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4762DF61-F3B7-49DB-BB7B-E8D86A350B39}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4762DF61-F3B7-49DB-BB7B-E8D86A350B39}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4762DF61-F3B7-49DB-BB7B-E8D86A350B39}.Debug|x64.Build.0 = Debug|Any CPU
+		{4762DF61-F3B7-49DB-BB7B-E8D86A350B39}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4762DF61-F3B7-49DB-BB7B-E8D86A350B39}.Debug|x86.Build.0 = Debug|Any CPU
+		{4762DF61-F3B7-49DB-BB7B-E8D86A350B39}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4762DF61-F3B7-49DB-BB7B-E8D86A350B39}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4762DF61-F3B7-49DB-BB7B-E8D86A350B39}.Release|x64.ActiveCfg = Release|Any CPU
+		{4762DF61-F3B7-49DB-BB7B-E8D86A350B39}.Release|x64.Build.0 = Release|Any CPU
+		{4762DF61-F3B7-49DB-BB7B-E8D86A350B39}.Release|x86.ActiveCfg = Release|Any CPU
+		{4762DF61-F3B7-49DB-BB7B-E8D86A350B39}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/MetricsPipeline.Core/DirectoryCounts.cs
+++ b/MetricsPipeline.Core/DirectoryCounts.cs
@@ -1,0 +1,9 @@
+namespace MetricsPipeline.Core;
+
+/// <summary>
+/// Represents counts and sizes for a directory scan.
+/// </summary>
+/// <param name="FileCount">Number of files discovered.</param>
+/// <param name="DirectoryCount">Number of directories discovered.</param>
+/// <param name="TotalBytes">Total bytes for all files.</param>
+public record DirectoryCounts(int FileCount, int DirectoryCount, long TotalBytes);

--- a/MetricsPipeline.Core/IDirectoryComparer.cs
+++ b/MetricsPipeline.Core/IDirectoryComparer.cs
@@ -1,0 +1,18 @@
+namespace MetricsPipeline.Core;
+
+/// <summary>
+/// Compares two directories and identifies differences.
+/// </summary>
+public interface IDirectoryComparer
+{
+    /// <summary>
+    /// Compares the source directory with the destination directory.
+    /// </summary>
+    /// <param name="sourcePath">Path to the source directory.</param>
+    /// <param name="destinationPath">Path to the destination directory.</param>
+    /// <param name="cancellationToken">Token to observe cancellation.</param>
+    Task<IReadOnlyCollection<MismatchRow>> CompareAsync(
+        string sourcePath,
+        string destinationPath,
+        CancellationToken cancellationToken = default);
+}

--- a/MetricsPipeline.Core/IDriveScanner.cs
+++ b/MetricsPipeline.Core/IDriveScanner.cs
@@ -1,0 +1,18 @@
+namespace MetricsPipeline.Core;
+
+public interface IDriveScanner
+{
+    /// <summary>
+    /// Enumerates all directories under the provided root path.
+    /// </summary>
+    /// <param name="rootPath">Root directory path.</param>
+    /// <param name="cancellationToken">Token to observe cancellation.</param>
+    Task<IEnumerable<string>> GetDirectoriesAsync(string rootPath, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Calculates file and directory counts for the specified path.
+    /// </summary>
+    /// <param name="path">Directory path.</param>
+    /// <param name="cancellationToken">Token to observe cancellation.</param>
+    Task<DirectoryCounts> GetCountsAsync(string path, CancellationToken cancellationToken = default);
+}

--- a/MetricsPipeline.Core/Infrastructure/Workers/DirectoryComparerWorker.cs
+++ b/MetricsPipeline.Core/Infrastructure/Workers/DirectoryComparerWorker.cs
@@ -1,0 +1,35 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace MetricsPipeline.Core.Infrastructure.Workers;
+
+/// <summary>
+/// Worker that compares two directories using <see cref="IDirectoryComparer"/>.
+/// </summary>
+public sealed class DirectoryComparerWorker : BackgroundService
+{
+    private readonly IDirectoryComparer _comparer;
+    private readonly ILogger<DirectoryComparerWorker> _logger;
+    private readonly string _source;
+    private readonly string _destination;
+
+    public DirectoryComparerWorker(IDirectoryComparer comparer, ILogger<DirectoryComparerWorker> logger, string source, string destination)
+    {
+        _comparer = comparer;
+        _logger = logger;
+        _source = source;
+        _destination = destination;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var mismatches = await _comparer.CompareAsync(_source, _destination, stoppingToken);
+        foreach (var mismatch in mismatches)
+        {
+            if (_logger.IsEnabled(LogLevel.Warning))
+            {
+                _logger.LogWarning("Mismatch: {path} - {type}", mismatch.RelativePath, mismatch.GetType().Name);
+            }
+        }
+    }
+}

--- a/MetricsPipeline.Core/Infrastructure/Workers/DriveScannerWorker.cs
+++ b/MetricsPipeline.Core/Infrastructure/Workers/DriveScannerWorker.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace MetricsPipeline.Core.Infrastructure.Workers;
+
+/// <summary>
+/// Worker that scans a drive using <see cref="IDriveScanner"/> and logs the results.
+/// </summary>
+public sealed class DriveScannerWorker : BackgroundService
+{
+    private readonly IDriveScanner _scanner;
+    private readonly ILogger<DriveScannerWorker> _logger;
+    private readonly string _rootPath;
+
+    public DriveScannerWorker(IDriveScanner scanner, ILogger<DriveScannerWorker> logger, string rootPath)
+    {
+        _scanner = scanner;
+        _logger = logger;
+        _rootPath = rootPath;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var directories = await _scanner.GetDirectoriesAsync(_rootPath, stoppingToken);
+        foreach (var dir in directories)
+        {
+            var counts = await _scanner.GetCountsAsync(dir, stoppingToken);
+            if (_logger.IsEnabled(LogLevel.Information))
+            {
+                _logger.LogInformation("{dir} -> {files} files, {dirs} dirs", dir, counts.FileCount, counts.DirectoryCount);
+            }
+        }
+    }
+}

--- a/MetricsPipeline.Core/MetricsPipeline.Core.csproj
+++ b/MetricsPipeline.Core/MetricsPipeline.Core.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.6" />
+  </ItemGroup>
+
+</Project>

--- a/MetricsPipeline.Core/MismatchRows.cs
+++ b/MetricsPipeline.Core/MismatchRows.cs
@@ -1,0 +1,22 @@
+namespace MetricsPipeline.Core;
+
+/// <summary>
+/// Base record for directory comparison mismatches.
+/// </summary>
+/// <param name="RelativePath">Path relative to the comparison root.</param>
+public abstract record MismatchRow(string RelativePath);
+
+/// <summary>
+/// Represents a file or directory missing from one side of the comparison.
+/// </summary>
+/// <param name="RelativePath">Path relative to the comparison root.</param>
+/// <param name="MissingOnSource">True if missing from the source directory.</param>
+public record MissingEntryRow(string RelativePath, bool MissingOnSource) : MismatchRow(RelativePath);
+
+/// <summary>
+/// Represents a size mismatch for a file present in both directories.
+/// </summary>
+/// <param name="RelativePath">Path relative to the comparison root.</param>
+/// <param name="SourceSize">Size of the source file.</param>
+/// <param name="DestinationSize">Size of the destination file.</param>
+public record SizeMismatchRow(string RelativePath, long SourceSize, long DestinationSize) : MismatchRow(RelativePath);

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository demonstrates a minimal setup for a worker service using **.NET 9**.
 The service, `DirectorySyncWorker`, processes background jobs that keep directories in sync across environments.
+It now includes a reusable library called `MetricsPipeline.Core` that provides drive
+scanning and directory comparison helpers.
 
 ## Prerequisites
 - .NET 9 SDK (install via `dotnet-install.sh` or from the official [download page](https://aka.ms/dotnet-download))
@@ -14,7 +16,24 @@ The service, `DirectorySyncWorker`, processes background jobs that keep director
 3. Run the worker with `dotnet run --project DirectorySyncWorker`.
 4. Execute tests and generate coverage: `dotnet test --collect:"XPlat Code Coverage"`.
 5. Disable telemetry during builds by setting `DOTNET_CLI_TELEMETRY_OPTOUT=1`.
+6. Build the core library alone via `dotnet build MetricsPipeline.Core` if desired.
+7. To scan a drive programmatically, inject an `IDriveScanner` implementation and
+   use the provided `DriveScannerWorker` for scheduled scans.
 
 This solution serves as a starting point for building background services.
 Refer to the [.NET 9 release notes](https://learn.microsoft.com/dotnet/core/whats-new/dotnet-9) for new features.
 Feel free to extend it with your own business logic and tests.
+
+## Project Structure
+- **DirectorySyncWorker** – executable worker service.
+- **MetricsPipeline.Core** – contains interfaces like `IDriveScanner` and
+  `IDirectoryComparer` plus model records for comparison results.
+- Worker classes reside under `MetricsPipeline.Core/Infrastructure/Workers` so
+  they can be shared across services.
+
+### Directory Scanning Example
+```csharp
+var scanner = serviceProvider.GetRequiredService<IDriveScanner>();
+var counts = await scanner.GetCountsAsync("/data");
+Console.WriteLine($"Files: {counts.FileCount}, Dirs: {counts.DirectoryCount}");
+```


### PR DESCRIPTION
## Summary
- create `MetricsPipeline.Core` class library
- define `IDriveScanner` and `IDirectoryComparer` interfaces
- add `DirectoryCounts` and mismatch row models
- implement shared worker classes for scanning and comparing
- update solution and README with usage notes

## Testing
- `dotnet test --no-build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_68541baf23588330880af1ee4477b1dc