### PR TITLE
Implement multi-drive coordination worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -391,6 +391,7 @@ FodyWeavers.xsd
 !.vscode/launch.json
 !.vscode/extensions.json
 *.code-workspace
+*.feature.cs
 
 # Local History for Visual Studio Code
 .history/

--- a/MetricsPipeline.Core.Tests/Features/MultiDriveCoordinator.feature
+++ b/MetricsPipeline.Core.Tests/Features/MultiDriveCoordinator.feature
@@ -1,0 +1,9 @@
+Feature: Multi Drive Coordinator
+  In order to process multiple root pairs
+  As a developer
+  I want the coordinator worker to aggregate counts for Google and Microsoft drives.
+
+  Scenario: aggregating counts
+    Given two root pairs exist
+    When the coordinator processes the queue
+    Then counts for all roots should be recorded

--- a/MetricsPipeline.Core.Tests/Steps/MultiDriveCoordinatorSteps.cs
+++ b/MetricsPipeline.Core.Tests/Steps/MultiDriveCoordinatorSteps.cs
@@ -1,0 +1,85 @@
+using System.Collections.Concurrent;
+using Reqnroll;
+using MetricsPipeline.Core;
+using MetricsPipeline.Core.Infrastructure.Workers;
+using FluentAssertions;
+
+namespace MetricsPipeline.Core.Tests.Steps;
+
+[Binding]
+public class MultiDriveCoordinatorSteps
+{
+    private readonly ConcurrentDictionary<string, DirectoryCounts> _google = new();
+    private readonly ConcurrentDictionary<string, DirectoryCounts> _microsoft = new();
+    private IEnumerable<(string GoogleRoot, string MicrosoftRoot)>? _pairs;
+
+    [Given("two root pairs exist")]
+    public void GivenTwoRootPairsExist()
+    {
+        _pairs = new List<(string, string)>
+        {
+            ("g1", "m1"),
+            ("g2", "m2")
+        };
+    }
+
+    [When("the coordinator processes the queue")]
+    public async Task WhenTheCoordinatorProcessesTheQueue()
+    {
+        var googleScanner = new StubScanner(new Dictionary<string, DirectoryCounts>
+        {
+            ["g1"] = new DirectoryCounts(1, 0, 0),
+            ["g2"] = new DirectoryCounts(1, 0, 0)
+        });
+        var microsoftScanner = new StubScanner(new Dictionary<string, DirectoryCounts>
+        {
+            ["m1"] = new DirectoryCounts(2, 0, 0),
+            ["m2"] = new DirectoryCounts(2, 0, 0)
+        });
+        var worker = new TestCoordinatorWorker(
+            googleScanner,
+            microsoftScanner,
+            _pairs!,
+            _google,
+            _microsoft);
+        await worker.RunAsync();
+    }
+
+    [Then("counts for all roots should be recorded")]
+    public void ThenCountsForAllRootsShouldBeRecorded()
+    {
+        _google.Should().HaveCount(2);
+        _microsoft.Should().HaveCount(2);
+    }
+}
+
+internal sealed class StubScanner : IDriveScanner
+{
+    private readonly IReadOnlyDictionary<string, DirectoryCounts> _data;
+
+    public StubScanner(IDictionary<string, DirectoryCounts> data)
+    {
+        _data = new Dictionary<string, DirectoryCounts>(data);
+    }
+
+    public Task<IEnumerable<string>> GetDirectoriesAsync(string rootPath, CancellationToken cancellationToken = default)
+        => Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
+
+    public Task<DirectoryCounts> GetCountsAsync(string path, CancellationToken cancellationToken = default)
+        => Task.FromResult(_data[path]);
+}
+
+internal sealed class TestCoordinatorWorker : MultiDriveCoordinatorWorker
+{
+    public TestCoordinatorWorker(
+        IDriveScanner google,
+        IDriveScanner microsoft,
+        IEnumerable<(string GoogleRoot, string MicrosoftRoot)> roots,
+        ConcurrentDictionary<string, DirectoryCounts> googleMap,
+        ConcurrentDictionary<string, DirectoryCounts> microsoftMap)
+        : base(google, microsoft, roots, googleMap, microsoftMap, new NullLogger<MultiDriveCoordinatorWorker>())
+    {
+    }
+
+    public Task RunAsync() => base.ExecuteAsync(CancellationToken.None);
+}

--- a/MetricsPipeline.Core/Infrastructure/Workers/MultiDriveCoordinatorWorker.cs
+++ b/MetricsPipeline.Core/Infrastructure/Workers/MultiDriveCoordinatorWorker.cs
@@ -1,0 +1,63 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System.Collections.Concurrent;
+
+namespace MetricsPipeline.Core.Infrastructure.Workers;
+
+/// <summary>
+/// Coordinates scanning of multiple root directory pairs across Google and Microsoft drives.
+/// </summary>
+public class MultiDriveCoordinatorWorker : BackgroundService
+{
+    private readonly IDriveScanner _googleScanner;
+    private readonly IDriveScanner _microsoftScanner;
+    private readonly IEnumerable<(string GoogleRoot, string MicrosoftRoot)> _roots;
+    private readonly ConcurrentDictionary<string, DirectoryCounts> _googleCounts;
+    private readonly ConcurrentDictionary<string, DirectoryCounts> _microsoftCounts;
+    private readonly ILogger<MultiDriveCoordinatorWorker> _logger;
+
+    public MultiDriveCoordinatorWorker(
+        IDriveScanner googleScanner,
+        IDriveScanner microsoftScanner,
+        IEnumerable<(string GoogleRoot, string MicrosoftRoot)> roots,
+        ConcurrentDictionary<string, DirectoryCounts> googleCounts,
+        ConcurrentDictionary<string, DirectoryCounts> microsoftCounts,
+        ILogger<MultiDriveCoordinatorWorker> logger)
+    {
+        _googleScanner = googleScanner;
+        _microsoftScanner = microsoftScanner;
+        _roots = roots;
+        _googleCounts = googleCounts;
+        _microsoftCounts = microsoftCounts;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var queue = new ConcurrentQueue<(string GoogleRoot, string MicrosoftRoot)>(_roots);
+        var workers = new List<Task>();
+        var workerCount = Environment.ProcessorCount * 2;
+
+        for (int i = 0; i < workerCount; i++)
+        {
+            workers.Add(Task.Run(async () =>
+            {
+                while (queue.TryDequeue(out var pair) && !stoppingToken.IsCancellationRequested)
+                {
+                    var gCounts = await _googleScanner.GetCountsAsync(pair.GoogleRoot, stoppingToken);
+                    _googleCounts[pair.GoogleRoot] = gCounts;
+
+                    var mCounts = await _microsoftScanner.GetCountsAsync(pair.MicrosoftRoot, stoppingToken);
+                    _microsoftCounts[pair.MicrosoftRoot] = mCounts;
+                }
+            }, stoppingToken));
+        }
+
+        await Task.WhenAll(workers);
+
+        if (_logger.IsEnabled(LogLevel.Information))
+        {
+            _logger.LogInformation("Aggregated {google} Google and {microsoft} Microsoft entries", _googleCounts.Count, _microsoftCounts.Count);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `MultiDriveCoordinatorWorker` for parallel scanning of drive pairs
- provide BDD tests for coordinator logic
- document new worker usage
- ignore generated feature artifacts in `.gitignore`

## Testing
- `dotnet test --no-restore`
- `dotnet test --collect:"XPlat Code Coverage"`

------
https://chatgpt.com/codex/tasks/task_e_68543221b88083308684ff2ad31da8e3