### PR TITLE
Add CLI for drive mismatch scanning

### DIFF
--- a/IdealComputingMachine.sln
+++ b/IdealComputingMachine.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MetricsPipeline.Core", "Met
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MetricsPipeline.Core.Tests", "MetricsPipeline.Core.Tests\MetricsPipeline.Core.Tests.csproj", "{E94766F7-BC0D-4022-8475-D6E3CD19960F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MetricsCli", "MetricsCli\MetricsCli.csproj", "{356EA6F0-8B76-4EFA-9DB1-C570846ECD04}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -55,6 +57,18 @@ Global
 		{E94766F7-BC0D-4022-8475-D6E3CD19960F}.Release|x64.Build.0 = Release|Any CPU
 		{E94766F7-BC0D-4022-8475-D6E3CD19960F}.Release|x86.ActiveCfg = Release|Any CPU
 		{E94766F7-BC0D-4022-8475-D6E3CD19960F}.Release|x86.Build.0 = Release|Any CPU
+		{356EA6F0-8B76-4EFA-9DB1-C570846ECD04}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{356EA6F0-8B76-4EFA-9DB1-C570846ECD04}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{356EA6F0-8B76-4EFA-9DB1-C570846ECD04}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{356EA6F0-8B76-4EFA-9DB1-C570846ECD04}.Debug|x64.Build.0 = Debug|Any CPU
+		{356EA6F0-8B76-4EFA-9DB1-C570846ECD04}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{356EA6F0-8B76-4EFA-9DB1-C570846ECD04}.Debug|x86.Build.0 = Debug|Any CPU
+		{356EA6F0-8B76-4EFA-9DB1-C570846ECD04}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{356EA6F0-8B76-4EFA-9DB1-C570846ECD04}.Release|Any CPU.Build.0 = Release|Any CPU
+		{356EA6F0-8B76-4EFA-9DB1-C570846ECD04}.Release|x64.ActiveCfg = Release|Any CPU
+		{356EA6F0-8B76-4EFA-9DB1-C570846ECD04}.Release|x64.Build.0 = Release|Any CPU
+		{356EA6F0-8B76-4EFA-9DB1-C570846ECD04}.Release|x86.ActiveCfg = Release|Any CPU
+		{356EA6F0-8B76-4EFA-9DB1-C570846ECD04}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/MetricsCli/MetricsCli.csproj
+++ b/MetricsCli/MetricsCli.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="Google.Apis.Auth" Version="1.69.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />
+    <PackageReference Include="Azure.Identity" Version="1.10.4" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../MetricsPipeline.Core/MetricsPipeline.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/MetricsCli/PipelineRunner.cs
+++ b/MetricsCli/PipelineRunner.cs
@@ -1,0 +1,44 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+using MetricsPipeline.Core;
+using MetricsPipeline.Core.Infrastructure.Workers;
+
+namespace MetricsCli;
+
+public static class PipelineRunner
+{
+    public static async Task RunAsync(Options options,
+        IDriveScanner googleScanner,
+        IDriveScanner microsoftScanner,
+        Stream output,
+        ILoggerFactory loggerFactory)
+    {
+        var googleCounts = new ConcurrentDictionary<string, DirectoryCounts>();
+        var microsoftCounts = new ConcurrentDictionary<string, DirectoryCounts>();
+        var worker = new CliCoordinatorWorker(googleScanner, microsoftScanner,
+            new[]{(options.GoogleRoot, options.MsRoot)},
+            googleCounts, microsoftCounts,
+            loggerFactory.CreateLogger<MultiDriveCoordinatorWorker>());
+        await worker.RunAsync();
+
+        var comparer = new DirectoryCountsComparer();
+        var differences = comparer.Compare(googleCounts, microsoftCounts);
+        var exporter = new CsvExporter();
+        await exporter.ExportAsync(differences, output);
+    }
+}
+
+internal sealed class CliCoordinatorWorker : MultiDriveCoordinatorWorker
+{
+    public CliCoordinatorWorker(IDriveScanner google,
+        IDriveScanner microsoft,
+        IEnumerable<(string GoogleRoot, string MicrosoftRoot)> roots,
+        ConcurrentDictionary<string, DirectoryCounts> gMap,
+        ConcurrentDictionary<string, DirectoryCounts> mMap,
+        ILogger<MultiDriveCoordinatorWorker> logger)
+        : base(google, microsoft, roots, gMap, mMap, logger)
+    {
+    }
+
+    public Task RunAsync() => base.ExecuteAsync(CancellationToken.None);
+}

--- a/MetricsCli/Program.cs
+++ b/MetricsCli/Program.cs
@@ -1,0 +1,83 @@
+using System.CommandLine;
+using Azure.Identity;
+using Google.Apis.Auth.OAuth2;
+using Google.Apis.Drive.v3;
+using Google.Apis.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Graph;
+using MetricsPipeline.Core;
+
+namespace MetricsCli;
+
+public static class Program
+{
+    public static async Task<int> Main(string[] args)
+    {
+        var cmd = BuildCommand();
+        return await cmd.InvokeAsync(args);
+    }
+
+    private static (RootCommand Command,
+        Option<string> Ms,
+        Option<string> Google,
+        Option<string?> Auth,
+        Option<string> Output,
+        Option<int> Dop) CreateDefinition()
+    {
+        var msRoot = new Option<string>("--ms-root") { IsRequired = true, Description = "Microsoft root path" };
+        var googleRoot = new Option<string>("--google-root") { IsRequired = true, Description = "Google Drive root" };
+        var googleAuth = new Option<string?>("--google-auth", description: "Path to Google credentials JSON") { IsRequired = false };
+        var output = new Option<string>("--output", () => "mismatches.csv", "CSV output file");
+        var maxDop = new Option<int>("--max-dop", () => Environment.ProcessorCount, "Max degree of parallelism");
+        var cmd = new RootCommand("Drive mismatch scanning tool");
+        cmd.AddOption(msRoot);
+        cmd.AddOption(googleRoot);
+        cmd.AddOption(googleAuth);
+        cmd.AddOption(output);
+        cmd.AddOption(maxDop);
+        return (cmd, msRoot, googleRoot, googleAuth, output, maxDop);
+    }
+
+    internal static RootCommand BuildCommand()
+    {
+        var def = CreateDefinition();
+        def.Command.SetHandler(async (string mRoot, string gRoot, string? auth, string outFile, int dop) =>
+        {
+            var options = new Options(mRoot, gRoot, outFile, auth ?? Environment.GetEnvironmentVariable("GOOGLE_AUTH"), dop);
+            var loggerFactory = LoggerFactory.Create(b => b.AddConsole());
+            var googleScanner = CreateGoogleScanner(options, loggerFactory.CreateLogger<GoogleDriveScanner>());
+            var msScanner = CreateMicrosoftScanner(options, loggerFactory.CreateLogger<GraphScanner>());
+            await using var stream = File.Create(options.Output);
+            await PipelineRunner.RunAsync(options, googleScanner, msScanner, stream, loggerFactory);
+        }, def.Ms, def.Google, def.Auth, def.Output, def.Dop);
+        return def.Command;
+    }
+
+    public static Options ParseOptions(string[] args)
+    {
+        var def = CreateDefinition();
+        var result = def.Command.Parse(args);
+        var msRoot = result.GetValueForOption(def.Ms)!;
+        var googleRoot = result.GetValueForOption(def.Google)!;
+        var auth = result.GetValueForOption(def.Auth) ?? Environment.GetEnvironmentVariable("GOOGLE_AUTH");
+        var output = result.GetValueForOption(def.Output)!;
+        var dop = result.GetValueForOption(def.Dop);
+        return new Options(msRoot, googleRoot, output, auth, dop);
+    }
+
+    private static GoogleDriveScanner CreateGoogleScanner(Options options, ILogger<GoogleDriveScanner> logger)
+    {
+        var authFile = options.GoogleAuth ?? throw new InvalidOperationException("Google credentials missing");
+        var credential = GoogleCredential.FromFile(authFile).CreateScoped(DriveService.Scope.DriveReadonly);
+        var service = new DriveService(new BaseClientService.Initializer { HttpClientInitializer = credential });
+        return new GoogleDriveScanner(service, logger, followShortcuts: false, maxConcurrency: options.MaxDop);
+    }
+
+    private static GraphScanner CreateMicrosoftScanner(Options options, ILogger<GraphScanner> logger)
+    {
+        var client = new GraphServiceClient(new DefaultAzureCredential());
+        return new GraphScanner(client, logger, options.MaxDop);
+    }
+}
+
+public record Options(string MsRoot, string GoogleRoot, string Output, string? GoogleAuth, int MaxDop);

--- a/MetricsPipeline.Core.Tests/Features/CommandLine.feature
+++ b/MetricsPipeline.Core.Tests/Features/CommandLine.feature
@@ -1,0 +1,13 @@
+Feature: Command Line
+  In order to run drive comparisons from a shell
+  As an operator
+  I want to parse options and export mismatches.
+
+  Scenario: defaulting google auth from environment
+    Given environment variable GOOGLE_AUTH is set to "cred.json"
+    When I parse the arguments "--ms-root m --google-root g"
+    Then the parsed options should contain "cred.json"
+
+  Scenario: exporting CSV results
+    When I run the CLI pipeline
+    Then the output should contain a CSV header

--- a/MetricsPipeline.Core.Tests/MetricsPipeline.Core.Tests.csproj
+++ b/MetricsPipeline.Core.Tests/MetricsPipeline.Core.Tests.csproj
@@ -19,6 +19,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../MetricsPipeline.Core/MetricsPipeline.Core.csproj" />
+    <ProjectReference Include="../MetricsCli/MetricsCli.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MetricsPipeline.Core.Tests/Steps/CommandLineSteps.cs
+++ b/MetricsPipeline.Core.Tests/Steps/CommandLineSteps.cs
@@ -1,0 +1,71 @@
+using System.IO;
+using System.Text;
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+using Reqnroll;
+using FluentAssertions;
+using MetricsCli;
+using MetricsPipeline.Core;
+
+namespace MetricsPipeline.Core.Tests.Steps;
+
+[Binding]
+public class CommandLineSteps
+{
+    private Options? _options;
+    private string? _csv;
+
+    [Given("environment variable GOOGLE_AUTH is set to \"(.*)\"")]
+    public void GivenEnvIsSet(string path)
+    {
+        Environment.SetEnvironmentVariable("GOOGLE_AUTH", path);
+    }
+
+    [When("I parse the arguments \"(.*)\"")]
+    public void WhenIParse(string args)
+    {
+        _options = Program.ParseOptions(args.Split(' '));
+    }
+
+    [Then("the parsed options should contain \"(.*)\"")]
+    public void ThenOptionsShouldContain(string expected)
+    {
+        _options!.GoogleAuth.Should().Be(expected);
+    }
+
+    [When("I run the CLI pipeline")]
+    public async Task WhenIRunPipeline()
+    {
+        var google = new CliStubScanner(new Dictionary<string, DirectoryCounts> { ["g"] = new DirectoryCounts(1,0,0) });
+        var ms = new CliStubScanner(new Dictionary<string, DirectoryCounts> { ["m"] = new DirectoryCounts(0,1,0) });
+        using var stream = new MemoryStream();
+        var loggerFactory = LoggerFactory.Create(b => { });
+        var options = new Options("m","g","out.csv","cred.json",1);
+        await PipelineRunner.RunAsync(options, google, ms, stream, loggerFactory);
+        stream.Position = 0;
+        using var reader = new StreamReader(stream, Encoding.UTF8, leaveOpen:true);
+        _csv = await reader.ReadToEndAsync();
+    }
+
+    [Then("the output should contain a CSV header")]
+    public void ThenOutputContainsHeader()
+    {
+        _csv!.Split('\n')[0].Should().Contain("Path");
+    }
+}
+
+internal sealed class CliStubScanner : IDriveScanner
+{
+    private readonly IReadOnlyDictionary<string, DirectoryCounts> _map;
+
+    public CliStubScanner(IDictionary<string, DirectoryCounts> map)
+    {
+        _map = new Dictionary<string, DirectoryCounts>(map);
+    }
+
+    public Task<IEnumerable<string>> GetDirectoriesAsync(string rootPath, CancellationToken cancellationToken = default)
+        => Task.FromResult<IEnumerable<string>>(Array.Empty<string>());
+
+    public Task<DirectoryCounts> GetCountsAsync(string path, CancellationToken cancellationToken = default)
+        => Task.FromResult(_map[path]);
+}

--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ for further processing.
 16. A new feature file exercises the comparer so coverage remains high.
 17. Example scripts now show how to pipe mismatches to a CSV file.
 18. The README clarifies installing the .NET 9 preview SDK for this project.
+19. The new `MetricsCli` tool runs the comparison pipeline from the command line.
+20. Provide Microsoft and Google root IDs via `--ms-root` and `--google-root`.
+21. Pass Google credentials with `--google-auth` or set the `GOOGLE_AUTH` environment variable.
+22. Use `--output` to write mismatches to a CSV file.
+23. Limit concurrency with the `--max-dop` option.
 
 ### Graph Scanning Example
 ```csharp


### PR DESCRIPTION
## Summary
- implement `MetricsCli` with System.CommandLine
- parse options including secrets from environment variables
- export mismatches using the existing pipeline
- add BDD tests for CLI behaviour
- document new tool in README

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-restore --no-build`
- `dotnet test --collect:"XPlat Code Coverage" --no-restore --no-build`


------
https://chatgpt.com/codex/tasks/task_e_685435ba0e5c8330a579eb896b29a444