### PR TITLE
Add CSV mismatch feature with DI

### DIFF
--- a/MetricsPipeline.Core.Tests/ComparisonContext.cs
+++ b/MetricsPipeline.Core.Tests/ComparisonContext.cs
@@ -1,0 +1,10 @@
+using Moq;
+using MetricsPipeline.Core;
+
+namespace MetricsPipeline.Core.Tests;
+
+public sealed class ComparisonContext
+{
+    public Mock<IGoogleScanner> GoogleMock { get; } = new(MockBehavior.Strict);
+    public Mock<IMicrosoftScanner> MicrosoftMock { get; } = new(MockBehavior.Strict);
+}

--- a/MetricsPipeline.Core.Tests/DependencyInjection.cs
+++ b/MetricsPipeline.Core.Tests/DependencyInjection.cs
@@ -1,0 +1,22 @@
+using System.IO;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Reqnroll;
+using Reqnroll.Microsoft.Extensions.DependencyInjection;
+
+namespace MetricsPipeline.Core.Tests;
+
+public static class DependencyInjection
+{
+    [ScenarioDependencies]
+    public static IServiceCollection CreateServices()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ComparisonContext>();
+        services.AddSingleton<IGoogleScanner>(sp => sp.GetRequiredService<ComparisonContext>().GoogleMock.Object);
+        services.AddSingleton<IMicrosoftScanner>(sp => sp.GetRequiredService<ComparisonContext>().MicrosoftMock.Object);
+        services.AddSingleton<MemoryStream>();
+        services.AddSingleton<ILoggerFactory>(sp => LoggerFactory.Create(b => { }));
+        return services;
+    }
+}

--- a/MetricsPipeline.Core.Tests/Features/CsvMismatch.feature
+++ b/MetricsPipeline.Core.Tests/Features/CsvMismatch.feature
@@ -1,0 +1,10 @@
+Feature: CSV Export
+  In order to review drive differences
+  As an operator
+  I want only mismatched counts to appear in the CSV.
+
+  Scenario: exporting mismatches for two roots
+    Given a google root returns a count of 1
+    And a microsoft root returns a count of 2
+    When the comparison pipeline runs
+    Then the CSV should contain two difference rows

--- a/MetricsPipeline.Core.Tests/IGoogleScanner.cs
+++ b/MetricsPipeline.Core.Tests/IGoogleScanner.cs
@@ -1,0 +1,6 @@
+using MetricsPipeline.Core;
+
+namespace MetricsPipeline.Core.Tests;
+
+public interface IGoogleScanner : IDriveScanner { }
+public interface IMicrosoftScanner : IDriveScanner { }

--- a/MetricsPipeline.Core.Tests/MetricsPipeline.Core.Tests.csproj
+++ b/MetricsPipeline.Core.Tests/MetricsPipeline.Core.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Polly" Version="8.6.1" />
+    <PackageReference Include="Reqnroll.Microsoft.Extensions.DependencyInjection" Version="2.4.1" />
     <PackageReference Include="Reqnroll.xUnit" Version="2.4.1" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/MetricsPipeline.Core.Tests/Steps/CsvMismatchSteps.cs
+++ b/MetricsPipeline.Core.Tests/Steps/CsvMismatchSteps.cs
@@ -1,0 +1,70 @@
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using Microsoft.Extensions.Logging;
+using Reqnroll;
+using MetricsCli;
+using MetricsPipeline.Core;
+
+namespace MetricsPipeline.Core.Tests.Steps;
+
+[Binding]
+public class CsvMismatchSteps
+{
+    private readonly IGoogleScanner _google;
+    private readonly IMicrosoftScanner _microsoft;
+    private readonly ComparisonContext _context;
+    private readonly MemoryStream _stream;
+    private readonly ILoggerFactory _loggerFactory;
+    private string? _csv;
+
+    public CsvMismatchSteps(
+        IGoogleScanner google,
+        IMicrosoftScanner microsoft,
+        ComparisonContext context,
+        MemoryStream stream,
+        ILoggerFactory loggerFactory)
+    {
+        _google = google;
+        _microsoft = microsoft;
+        _context = context;
+        _stream = stream;
+        _loggerFactory = loggerFactory;
+    }
+
+    [Given(@"a google root returns a count of (\d+)")]
+    public void GivenAGoogleRootReturnsACountOf(int count)
+    {
+        _context.GoogleMock
+            .Setup(s => s.GetCountsAsync("g", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DirectoryCounts(count, 0, 0));
+    }
+
+    [Given(@"a microsoft root returns a count of (\d+)")]
+    public void GivenAMicrosoftRootReturnsACountOf(int count)
+    {
+        _context.MicrosoftMock
+            .Setup(s => s.GetCountsAsync("m", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DirectoryCounts(count, 0, 0));
+    }
+
+    [When("the comparison pipeline runs")]
+    public async Task WhenTheComparisonPipelineRuns()
+    {
+        var options = new Options("m", "g", "out.csv", "cred.json", 1);
+        await PipelineRunner.RunAsync(options, _google, _microsoft, _stream, _loggerFactory);
+        _stream.Position = 0;
+        using var reader = new StreamReader(_stream);
+        _csv = await reader.ReadToEndAsync();
+    }
+
+    [Then("the CSV should contain two difference rows")]
+    public void ThenTheCsvShouldContainTwoDifferenceRows()
+    {
+        var lines = _csv!.Split('\n').Where(l => !string.IsNullOrWhiteSpace(l)).ToArray();
+        lines.Should().HaveCount(3);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ for further processing.
 21. Pass Google credentials with `--google-auth` or set the `GOOGLE_AUTH` environment variable.
 22. Use `--output` to write mismatches to a CSV file.
 23. Limit concurrency with the `--max-dop` option.
+24. Step definitions now resolve services via Microsoft.Extensions.DependencyInjection.
+25. `ScenarioDependencies` registers mocks for pipeline BDD tests.
+26. A new feature checks that only mismatched entries reach the CSV export.
+27. Moq supplies scanner stubs so tests remain fast and isolated.
+28. Run `dotnet test --collect:"XPlat Code Coverage"` to verify coverage above 80%.
 
 ### Graph Scanning Example
 ```csharp


### PR DESCRIPTION
## Summary
- add feature covering CSV export with mismatches
- implement CsvMismatchSteps using dependency injection
- register mocks with ScenarioDependencies
- document new DI test setup and coverage advice
- include Reqnroll DI package

## Testing
- `dotnet test --collect:"XPlat Code Coverage"`

------
https://chatgpt.com/codex/tasks/task_e_685438e0da388330bb12d05fccbd0f8c