### PR TITLE
Improve README and CLI

### DIFF
--- a/MetricsCli/Program.cs
+++ b/MetricsCli/Program.cs
@@ -22,34 +22,37 @@ public static class Program
         Option<string> Google,
         Option<string?> Auth,
         Option<string> Output,
-        Option<int> Dop) CreateDefinition()
+        Option<int> Dop,
+        Option<bool> Follow) CreateDefinition()
     {
         var msRoot = new Option<string>("--ms-root") { IsRequired = true, Description = "Microsoft root path" };
         var googleRoot = new Option<string>("--google-root") { IsRequired = true, Description = "Google Drive root" };
         var googleAuth = new Option<string?>("--google-auth", description: "Path to Google credentials JSON") { IsRequired = false };
         var output = new Option<string>("--output", () => "mismatches.csv", "CSV output file");
         var maxDop = new Option<int>("--max-dop", () => Environment.ProcessorCount, "Max degree of parallelism");
+        var follow = new Option<bool>("--follow-shortcuts", description: "Resolve Google Drive shortcuts");
         var cmd = new RootCommand("Drive mismatch scanning tool");
         cmd.AddOption(msRoot);
         cmd.AddOption(googleRoot);
         cmd.AddOption(googleAuth);
         cmd.AddOption(output);
         cmd.AddOption(maxDop);
-        return (cmd, msRoot, googleRoot, googleAuth, output, maxDop);
+        cmd.AddOption(follow);
+        return (cmd, msRoot, googleRoot, googleAuth, output, maxDop, follow);
     }
 
     internal static RootCommand BuildCommand()
     {
         var def = CreateDefinition();
-        def.Command.SetHandler(async (string mRoot, string gRoot, string? auth, string outFile, int dop) =>
+        def.Command.SetHandler(async (string mRoot, string gRoot, string? auth, string outFile, int dop, bool follow) =>
         {
-            var options = new Options(mRoot, gRoot, outFile, auth ?? Environment.GetEnvironmentVariable("GOOGLE_AUTH"), dop);
+            var options = new Options(mRoot, gRoot, outFile, auth ?? Environment.GetEnvironmentVariable("GOOGLE_AUTH"), dop, follow);
             var loggerFactory = LoggerFactory.Create(b => b.AddConsole());
             var googleScanner = CreateGoogleScanner(options, loggerFactory.CreateLogger<GoogleDriveScanner>());
             var msScanner = CreateMicrosoftScanner(options, loggerFactory.CreateLogger<GraphScanner>());
             await using var stream = File.Create(options.Output);
             await PipelineRunner.RunAsync(options, googleScanner, msScanner, stream, loggerFactory);
-        }, def.Ms, def.Google, def.Auth, def.Output, def.Dop);
+        }, def.Ms, def.Google, def.Auth, def.Output, def.Dop, def.Follow);
         return def.Command;
     }
 
@@ -62,7 +65,8 @@ public static class Program
         var auth = result.GetValueForOption(def.Auth) ?? Environment.GetEnvironmentVariable("GOOGLE_AUTH");
         var output = result.GetValueForOption(def.Output)!;
         var dop = result.GetValueForOption(def.Dop);
-        return new Options(msRoot, googleRoot, output, auth, dop);
+        var follow = result.GetValueForOption(def.Follow);
+        return new Options(msRoot, googleRoot, output, auth, dop, follow);
     }
 
     private static GoogleDriveScanner CreateGoogleScanner(Options options, ILogger<GoogleDriveScanner> logger)
@@ -70,7 +74,7 @@ public static class Program
         var authFile = options.GoogleAuth ?? throw new InvalidOperationException("Google credentials missing");
         var credential = GoogleCredential.FromFile(authFile).CreateScoped(DriveService.Scope.DriveReadonly);
         var service = new DriveService(new BaseClientService.Initializer { HttpClientInitializer = credential });
-        return new GoogleDriveScanner(service, logger, followShortcuts: false, maxConcurrency: options.MaxDop);
+        return new GoogleDriveScanner(service, logger, followShortcuts: options.FollowShortcuts, maxConcurrency: options.MaxDop);
     }
 
     private static GraphScanner CreateMicrosoftScanner(Options options, ILogger<GraphScanner> logger)
@@ -80,4 +84,4 @@ public static class Program
     }
 }
 
-public record Options(string MsRoot, string GoogleRoot, string Output, string? GoogleAuth, int MaxDop);
+public record Options(string MsRoot, string GoogleRoot, string Output, string? GoogleAuth, int MaxDop, bool FollowShortcuts);

--- a/MetricsPipeline.Core.Tests/Steps/CommandLineSteps.cs
+++ b/MetricsPipeline.Core.Tests/Steps/CommandLineSteps.cs
@@ -40,7 +40,7 @@ public class CommandLineSteps
         var ms = new CliStubScanner(new Dictionary<string, DirectoryCounts> { ["m"] = new DirectoryCounts(0,1,0) });
         using var stream = new MemoryStream();
         var loggerFactory = LoggerFactory.Create(b => { });
-        var options = new Options("m","g","out.csv","cred.json",1);
+        var options = new Options("m","g","out.csv","cred.json",1,false);
         await PipelineRunner.RunAsync(options, google, ms, stream, loggerFactory);
         stream.Position = 0;
         using var reader = new StreamReader(stream, Encoding.UTF8, leaveOpen:true);

--- a/MetricsPipeline.Core.Tests/Steps/CsvMismatchSteps.cs
+++ b/MetricsPipeline.Core.Tests/Steps/CsvMismatchSteps.cs
@@ -54,7 +54,7 @@ public class CsvMismatchSteps
     [When("the comparison pipeline runs")]
     public async Task WhenTheComparisonPipelineRuns()
     {
-        var options = new Options("m", "g", "out.csv", "cred.json", 1);
+        var options = new Options("m", "g", "out.csv", "cred.json", 1, false);
         await PipelineRunner.RunAsync(options, _google, _microsoft, _stream, _loggerFactory);
         _stream.Position = 0;
         using var reader = new StreamReader(_stream);

--- a/README.md
+++ b/README.md
@@ -1,166 +1,107 @@
 # Ideal Computing Machine
 
-This repository demonstrates a minimal setup for a worker service using **.NET 9**.
-The service, `DirectorySyncWorker`, processes background jobs that keep directories in sync across environments.
-It now includes a reusable library called `MetricsPipeline.Core` that provides drive
-scanning and directory comparison helpers.
-A new `GraphScanner` leverages the Microsoft Graph SDK to enumerate OneDrive or
-SharePoint document libraries. It automatically handles throttling and parallel
-requests.
-The library now also offers a `GoogleDriveScanner` for listing folders in
-Google Drive. It shares the same concurrency limits and retry behaviour as the
-Graph implementation and can optionally resolve shortcuts.
+## Overview
 
-A new `MultiDriveCoordinatorWorker` coordinates scanning of Google and
-Microsoft roots in parallel. It uses a work queue seeded with pairs of root
-paths and fans out workers based on the CPU count to maximise throughput.
-Aggregated file counts for both platforms are stored in memory for later
-processing or comparison. The new `DirectoryCountsComparer` can merge these maps and expose only mismatched paths
-for further processing.
+Ideal Computing Machine demonstrates a minimal background worker and command line
+tool built with **.NET&nbsp;9**. `DirectorySyncWorker` coordinates directory
+scans across Microsoft and Google drives using reusable helpers from the
+`MetricsPipeline.Core` library. The library provides:
 
-## Prerequisites
-- .NET 9 SDK (install via `dotnet-install.sh` or from the official [download page](https://aka.ms/dotnet-download)) (preview)
-- A Unix-like shell capable of running bash scripts
-- Git for version control
-- `Microsoft.Graph` NuGet package for Graph scanning features
-- `Google.Apis.Drive.v3` package for Google Drive integration
+* `GraphScanner` for enumerating OneDrive or SharePoint locations via Microsoft
+  Graph.
+* `GoogleDriveScanner` for traversing Google Drive. It can optionally resolve
+  shortcut targets when `--follow-shortcuts` is enabled.
+* `MultiDriveCoordinatorWorker` to aggregate counts from both platforms in
+  parallel.
+* `DirectoryCountsComparer` and `CsvExporter` to report mismatched folder
+  statistics.
 
-## Usage
-1. Restore dependencies with `dotnet restore`.
-2. Build the solution using `dotnet build`.
-3. Run the worker with `dotnet run --project DirectorySyncWorker`.
-4. Execute tests and generate coverage: `dotnet test --collect:"XPlat Code Coverage"`.
-5. Disable telemetry during builds by setting `DOTNET_CLI_TELEMETRY_OPTOUT=1`.
-6. Build the core library alone via `dotnet build MetricsPipeline.Core` if desired.
-7. To scan a drive programmatically, inject an `IDriveScanner` implementation and
-   use the provided `DriveScannerWorker` for scheduled scans.
-8. The test suite now uses Reqnroll for BDD scenarios. Run `dotnet test` to
-   execute feature files and unit tests.
-9. Unit tests reside in the `MetricsPipeline.Core.Tests` project and verify
-   `GraphScanner` behaviour.
-10. `GoogleDriveScanner` can be used to enumerate folders from Google Drive. Use
-    the `--follow-shortcuts` option to resolve shortcut targets automatically.
-11. Use `MultiDriveCoordinatorWorker` to process Google and Microsoft roots
-    concurrently. Seed it with tuples of root IDs and it will fan out scanning
-    tasks according to your CPU count.
-12. A new feature file validates the coordinator behaviour with BDD tests,
-    ensuring counts are aggregated correctly.
-13. When running inside a minimal container you may set
-    `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1` to suppress locale warnings.
+Scanning is recursive by default so nested folders are processed automatically.
+When `--follow-shortcuts` is specified, Google Drive shortcut items pointing to
+folders are also descended into.
 
-14. Use `DirectoryCountsComparer` to join Google and Microsoft maps and spot count mismatches.
-15. `CsvExporter` streams these results directly to disk or stdout using `StreamWriter`.
-16. A new feature file exercises the comparer so coverage remains high.
-17. Example scripts now show how to pipe mismatches to a CSV file.
-18. The README clarifies installing the .NET 9 preview SDK for this project.
-19. The new `MetricsCli` tool runs the comparison pipeline from the command line.
-20. Provide Microsoft and Google root IDs via `--ms-root` and `--google-root`.
-21. Pass Google credentials with `--google-auth` or set the `GOOGLE_AUTH` environment variable.
-22. Use `--output` to write mismatches to a CSV file.
-23. Limit concurrency with the `--max-dop` option.
-24. Step definitions now resolve services via Microsoft.Extensions.DependencyInjection.
-25. `ScenarioDependencies` registers mocks for pipeline BDD tests.
-26. A new feature checks that only mismatched entries reach the CSV export.
-27. Moq supplies scanner stubs so tests remain fast and isolated.
+## Setup
 
-28. Run `dotnet test --collect:"XPlat Code Coverage"` to verify coverage above 80%.
-29. Configure OAuth credentials for Microsoft and Google before running scanners.
-30. The CLI now supports environment variables for secret management.
+1. Install the .NET&nbsp;9 SDK (use `dotnet-install.sh` or
+   [download](https://aka.ms/dotnet-download)).
+2. Run `dotnet restore` to fetch dependencies.
+3. Build the solution with `dotnet build`.
+4. Disable telemetry if desired: `export DOTNET_CLI_TELEMETRY_OPTOUT=1`.
+5. Execute `dotnet run --project DirectorySyncWorker` to launch the sample
+   worker service.
 
-## OAuth Configuration
+## OAuth configuration
 
-### Microsoft Graph
-1. Register an application in Azure Active Directory and grant `Files.Read.All` and
-   `Sites.Read.All` API permissions.
-2. Create a client secret and set `AZURE_CLIENT_ID`, `AZURE_TENANT_ID` and
-   `AZURE_CLIENT_SECRET` environment variables.
-3. The sample uses `DefaultAzureCredential` so tokens are acquired automatically
-   when these variables are present or you are logged in with `Azure CLI`.
+### Register a Microsoft application
 
-### Google Drive
-1. Create a Google Cloud project and enable the Drive API.
-2. Generate a service account key or OAuth client credentials and download the
-   JSON file.
-3. Provide the file path via `--google-auth` or set the `GOOGLE_AUTH`
-   environment variable so the scanners can authenticate.
+1. Sign in to the [Azure portal](https://portal.azure.com/) and open
+   **Azure&nbsp;Active Directory**.
+2. Choose **App registrations** &rarr; **New registration** and create an app.
+3. Under **API permissions** add `Files.Read.All` and `Sites.Read.All` as
+   application permissions and grant admin consent.
+4. In **Certificates &amp; secrets** create a client secret.
+5. Note the **Application (client) ID** and **Directory (tenant) ID** and set
+   `AZURE_CLIENT_ID`, `AZURE_TENANT_ID` and `AZURE_CLIENT_SECRET` in your shell.
 
+### Register a Google application
 
-### Graph Scanning Example
-```csharp
-var credential = new DefaultAzureCredential();
-var graphClient = new GraphServiceClient(credential);
-var scanner = new GraphScanner(graphClient, logger);
-var folders = await scanner.GetDirectoriesAsync("{driveId}:{rootItemId}");
-```
+1. Visit the [Google Cloud Console](https://console.cloud.google.com/)
+   and create a new project.
+2. Enable the **Google Drive API** for the project.
+3. Create a **Service account** and download its key as JSON.
+4. Share the target Google Drive folder with that service account.
+5. Provide the JSON path via `--google-auth` or set the `GOOGLE_AUTH`
+   environment variable.
 
-The scanner restricts concurrency with `SemaphoreSlim` and retries 429 responses
-using Polly's `WaitAndRetryAsync` policy.
+## Running the CLI
 
-### Google Drive Scanning Example
-```csharp
-var service = new DriveService(new BaseClientService.Initializer());
-var scanner = new GoogleDriveScanner(service, logger, followShortcuts: true);
-var folders = await scanner.GetDirectoriesAsync("{folderId}");
-```
-The Google implementation also uses a semaphore to limit concurrent requests and
-applies exponential back-off when the Drive API returns 429 or 503 errors.
-
-This solution serves as a starting point for building background services.
-Refer to the [.NET 9 release notes](https://learn.microsoft.com/dotnet/core/whats-new/dotnet-9) for new features.
-Feel free to extend it with your own business logic and tests.
-
-## Project Structure
-- **DirectorySyncWorker** – executable worker service.
-- **MetricsPipeline.Core** – contains interfaces like `IDriveScanner` and
-  `IDirectoryComparer` plus model records for comparison results.
-- Worker classes reside under `MetricsPipeline.Core/Infrastructure/Workers` so
-  they can be shared across services.
-
-### Directory Scanning Example
-```csharp
-var scanner = serviceProvider.GetRequiredService<IDriveScanner>();
-var counts = await scanner.GetCountsAsync("/data");
-Console.WriteLine($"Files: {counts.FileCount}, Dirs: {counts.DirectoryCount}");
-```
-
-### Coordinated Drive Example
-```csharp
-var pairs = new[]{("gRoot","mRoot")};
-var googleMap = new ConcurrentDictionary<string, DirectoryCounts>();
-var msMap = new ConcurrentDictionary<string, DirectoryCounts>();
-var worker = new MultiDriveCoordinatorWorker(gScanner, mScanner, pairs, googleMap, msMap, logger);
-await worker.StartAsync();
-```
-
-## Command Line Interface
-
-Run the CLI from the repository root:
+Invoke the CLI from the repository root:
 
 ```bash
 dotnet run --project MetricsCli -- \
   --ms-root <drive-id> --google-root <folder-id> \
   --google-auth creds.json --output mismatches.csv \
-  --max-dop 4
+  --follow-shortcuts --max-dop 4
 ```
 
-### Options
-* `--ms-root` – Microsoft Graph path or ID to scan.
+**Options**
+
+* `--ms-root` – Microsoft Graph path or drive ID to scan.
 * `--google-root` – Google Drive folder to compare.
-* `--google-auth` – path to OAuth credentials JSON (defaults to `GOOGLE_AUTH`).
+* `--google-auth` – path to OAuth credentials JSON.
 * `--output` – CSV file for mismatch results.
 * `--max-dop` – maximum concurrency for API calls.
+* `--follow-shortcuts` – recursively resolve Google shortcuts that point to
+  folders.
 
-Currently the tool compares a single pair of roots and only counts folders and
-files. It does not yet validate file content or sizes.
+## Docker usage
 
-## Testing and Coverage
-
-Execute the full test suite with coverage collection:
+Container images can be built for automated deployments:
 
 ```bash
-dotnet test --collect:"XPlat Code Coverage"
+docker build -t metrics .
+docker run --rm \
+  -e AZURE_CLIENT_ID=$AZURE_CLIENT_ID \
+  -e AZURE_TENANT_ID=$AZURE_TENANT_ID \
+  -e AZURE_CLIENT_SECRET=$AZURE_CLIENT_SECRET \
+  -e GOOGLE_AUTH=/secrets/creds.json \
+  metrics --ms-root <drive-id> --google-root <folder-id>
 ```
 
-Coverage reports are written to `MetricsPipeline.Core.Tests/TestResults` in
-`coverage.cobertura.xml`. Use `reportgenerator` or a similar tool to produce an
-HTML summary. Aim for coverage above 80% to catch regressions.
+Ensure your credentials file is mounted or baked into the container image. When
+running in Docker set `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1` to suppress
+locale warnings.
+
+## Testing
+
+Run the full test suite including coverage collection:
+
+```bash
+dotnet test --no-build --no-restore --collect:"XPlat Code Coverage"
+```
+
+CI executions use the same command and expect coverage above 80%. Coverage
+reports are written to `MetricsPipeline.Core.Tests/TestResults` as
+`coverage.cobertura.xml` and can be converted to HTML with tools like
+`reportgenerator`.
+


### PR DESCRIPTION
## Summary
- reorganize README with clearer sections
- document MSFT and Google OAuth setup
- add Docker usage notes
- explain follow-shortcuts recursive scanning
- clarify CI coverage expectations
- add `--follow-shortcuts` option to the CLI

## Testing
- `dotnet test --no-restore --no-build`
- `dotnet test --no-restore --no-build --collect:"XPlat Code Coverage"`


------
https://chatgpt.com/codex/tasks/task_e_68543e55ef00833080e52ffffd120f8d