### PR TITLE
Implement directory comparer

### DIFF
--- a/MetricsPipeline.Core.Tests/DirectoryComparerTests.cs
+++ b/MetricsPipeline.Core.Tests/DirectoryComparerTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+using MetricsPipeline.Core;
+
+namespace MetricsPipeline.Core.Tests;
+
+public class DirectoryComparerTests
+{
+    [Fact]
+    public async Task CompareAsync_InvokesScannerForBothPaths()
+    {
+        var scanner = new Mock<IDriveScanner>();
+        scanner.Setup(s => s.GetDirectoriesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+               .ReturnsAsync(Array.Empty<string>());
+
+        var comparer = new DirectoryComparer(scanner.Object);
+
+        using var tmp = new TempDir();
+        var src = Path.Combine(tmp.Path, "src");
+        var dst = Path.Combine(tmp.Path, "dst");
+        Directory.CreateDirectory(src);
+        Directory.CreateDirectory(dst);
+
+        await comparer.CompareAsync(src, dst);
+
+        scanner.Verify(s => s.GetDirectoriesAsync(src, It.IsAny<CancellationToken>()), Times.Once());
+        scanner.Verify(s => s.GetDirectoriesAsync(dst, It.IsAny<CancellationToken>()), Times.Once());
+    }
+}
+
+internal sealed class TempDir : IDisposable
+{
+    public string Path { get; }
+
+    public TempDir()
+    {
+        Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(Path))
+            Directory.Delete(Path, true);
+    }
+}

--- a/MetricsPipeline.Core.Tests/Features/DirectoryComparer.feature
+++ b/MetricsPipeline.Core.Tests/Features/DirectoryComparer.feature
@@ -1,0 +1,11 @@
+Feature: Directory Comparer
+  In order to validate local copies
+  As a developer
+  I want missing or mismatched files reported.
+
+  Scenario: comparing two folders
+    Given the source directory contains "a.txt" with 10 bytes
+    And the source directory contains "b.txt" with 5 bytes
+    And the destination directory contains "b.txt" with 7 bytes
+    When I compare the source and destination directories
+    Then two mismatches should be reported

--- a/MetricsPipeline.Core.Tests/Steps/DirectoryComparerSteps.cs
+++ b/MetricsPipeline.Core.Tests/Steps/DirectoryComparerSteps.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Reqnroll;
+using MetricsPipeline.Core;
+
+namespace MetricsPipeline.Core.Tests.Steps;
+
+[Binding]
+public class DirectoryComparerSteps : IDisposable
+{
+    private readonly string _root;
+    private readonly string _source;
+    private readonly string _destination;
+    private List<MismatchRow>? _rows;
+
+    public DirectoryComparerSteps()
+    {
+        _root = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        _source = Path.Combine(_root, "src");
+        _destination = Path.Combine(_root, "dst");
+        Directory.CreateDirectory(_source);
+        Directory.CreateDirectory(_destination);
+    }
+
+    [Given("the source directory contains \"(.*)\" with (\d+) bytes")]
+    public void GivenSourceFile(string name, int bytes)
+    {
+        File.WriteAllBytes(Path.Combine(_source, name), new byte[bytes]);
+    }
+
+    [Given("the destination directory contains \"(.*)\" with (\d+) bytes")]
+    public void GivenDestinationFile(string name, int bytes)
+    {
+        File.WriteAllBytes(Path.Combine(_destination, name), new byte[bytes]);
+    }
+
+    [When("I compare the source and destination directories")]
+    public async Task WhenICompare()
+    {
+        var comparer = new DirectoryComparer(new DirectoryScanner());
+        _rows = (await comparer.CompareAsync(_source, _destination)).ToList();
+    }
+
+    [Then("two mismatches should be reported")]
+    public void ThenTwoMismatches()
+    {
+        _rows.Should().HaveCount(2);
+        _rows.Should().ContainSingle(r => r is MissingEntryRow);
+        _rows.Should().ContainSingle(r => r is SizeMismatchRow);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+            Directory.Delete(_root, true);
+    }
+}

--- a/MetricsPipeline.Core/DirectoryComparer.cs
+++ b/MetricsPipeline.Core/DirectoryComparer.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MetricsPipeline.Core;
+
+/// <summary>
+/// Compares two directories using an <see cref="IDriveScanner"/> implementation.
+/// </summary>
+public sealed class DirectoryComparer : IDirectoryComparer
+{
+    private readonly IDriveScanner _scanner;
+
+    public DirectoryComparer(IDriveScanner scanner)
+    {
+        _scanner = scanner;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyCollection<MismatchRow>> CompareAsync(
+        string sourcePath,
+        string destinationPath,
+        CancellationToken cancellationToken = default)
+    {
+        var mismatches = new List<MismatchRow>();
+
+        var srcDirs = (await _scanner.GetDirectoriesAsync(sourcePath, cancellationToken))
+            .Select(d => Path.GetRelativePath(sourcePath, d));
+        var dstDirs = (await _scanner.GetDirectoriesAsync(destinationPath, cancellationToken))
+            .Select(d => Path.GetRelativePath(destinationPath, d));
+
+        var allDirs = new HashSet<string>(srcDirs, StringComparer.OrdinalIgnoreCase);
+        foreach (var d in dstDirs)
+        {
+            allDirs.Add(d);
+        }
+
+        foreach (var dir in allDirs.Append(string.Empty))
+        {
+            var srcDir = Path.Combine(sourcePath, dir);
+            var dstDir = Path.Combine(destinationPath, dir);
+            var srcExists = Directory.Exists(srcDir);
+            var dstExists = Directory.Exists(dstDir);
+
+            if (!srcExists || !dstExists)
+            {
+                mismatches.Add(new MissingEntryRow(dir, !srcExists));
+                continue;
+            }
+
+            CompareFiles(srcDir, dstDir, dir, mismatches);
+        }
+
+        return mismatches;
+    }
+
+    private static void CompareFiles(string srcDir, string dstDir, string prefix, List<MismatchRow> mismatches)
+    {
+        var srcFiles = Directory.EnumerateFiles(srcDir).ToDictionary(Path.GetFileName, f => f, StringComparer.OrdinalIgnoreCase);
+        var dstFiles = Directory.EnumerateFiles(dstDir).ToDictionary(Path.GetFileName, f => f, StringComparer.OrdinalIgnoreCase);
+        foreach (var name in srcFiles.Keys.Union(dstFiles.Keys))
+        {
+            var srcExists = srcFiles.TryGetValue(name, out var sPath);
+            var dstExists = dstFiles.TryGetValue(name, out var dPath);
+            var rel = Path.Combine(prefix, name).TrimStart(Path.DirectorySeparatorChar);
+
+            if (!srcExists)
+            {
+                mismatches.Add(new MissingEntryRow(rel, true));
+            }
+            else if (!dstExists)
+            {
+                mismatches.Add(new MissingEntryRow(rel, false));
+            }
+            else
+            {
+                var sSize = new FileInfo(sPath).Length;
+                var dSize = new FileInfo(dPath).Length;
+                if (sSize != dSize)
+                {
+                    mismatches.Add(new SizeMismatchRow(rel, sSize, dSize));
+                }
+            }
+        }
+    }
+}

--- a/MetricsPipeline.Core/DirectoryScanner.cs
+++ b/MetricsPipeline.Core/DirectoryScanner.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MetricsPipeline.Core;
+
+/// <summary>
+/// Scans the local file system for directory information.
+/// </summary>
+public class DirectoryScanner : IDriveScanner
+{
+    /// <inheritdoc />
+    public Task<IEnumerable<string>> GetDirectoriesAsync(string rootPath, CancellationToken cancellationToken = default)
+    {
+        var dirs = Directory.EnumerateDirectories(rootPath, "*", SearchOption.AllDirectories);
+        return Task.FromResult<IEnumerable<string>>(dirs.ToArray());
+    }
+
+    /// <inheritdoc />
+    public Task<DirectoryCounts> GetCountsAsync(string path, CancellationToken cancellationToken = default)
+    {
+        var files = Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories);
+        var dirs = Directory.EnumerateDirectories(path, "*", SearchOption.AllDirectories);
+        long bytes = files.Sum(f => new FileInfo(f).Length);
+        return Task.FromResult(new DirectoryCounts(files.Count(), dirs.Count(), bytes));
+    }
+}

--- a/MetricsPipeline.Core/Infrastructure/Workers/DirectoryComparerWorker.cs
+++ b/MetricsPipeline.Core/Infrastructure/Workers/DirectoryComparerWorker.cs
@@ -4,18 +4,18 @@ using Microsoft.Extensions.Logging;
 namespace MetricsPipeline.Core.Infrastructure.Workers;
 
 /// <summary>
-/// Worker that compares two directories using <see cref="IDirectoryComparer"/>.
+/// Worker that compares two directories using <see cref="DirectoryComparer"/>.
 /// </summary>
 public sealed class DirectoryComparerWorker : BackgroundService
 {
-    private readonly IDirectoryComparer _comparer;
+    private readonly IDriveScanner _scanner;
     private readonly ILogger<DirectoryComparerWorker> _logger;
     private readonly string _source;
     private readonly string _destination;
 
-    public DirectoryComparerWorker(IDirectoryComparer comparer, ILogger<DirectoryComparerWorker> logger, string source, string destination)
+    public DirectoryComparerWorker(IDriveScanner scanner, ILogger<DirectoryComparerWorker> logger, string source, string destination)
     {
-        _comparer = comparer;
+        _scanner = scanner;
         _logger = logger;
         _source = source;
         _destination = destination;
@@ -23,7 +23,8 @@ public sealed class DirectoryComparerWorker : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        var mismatches = await _comparer.CompareAsync(_source, _destination, stoppingToken);
+        var comparer = new DirectoryComparer(_scanner);
+        var mismatches = await comparer.CompareAsync(_source, _destination, stoppingToken);
         foreach (var mismatch in mismatches)
         {
             if (_logger.IsEnabled(LogLevel.Warning))

--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ for further processing.
 28. Run `dotnet test --collect:"XPlat Code Coverage"` to verify coverage above 80%.
 29. Configure OAuth credentials for Microsoft and Google before running scanners.
 30. The CLI now supports environment variables for secret management.
+31. `DirectoryScanner` provides local folder enumeration for comparisons.
+32. `DirectoryComparer` checks two paths and reports missing or mismatched files.
+33. `DirectoryComparerWorker` logs these issues when run as a background service.
+34. A new feature file verifies the comparer end to end using temporary folders.
+35. Unit tests confirm the comparer interacts with the scanner through Moq.
 
 ## OAuth Configuration
 


### PR DESCRIPTION
## Summary
- add `DirectoryScanner` for local filesystem enumeration
- implement `DirectoryComparer` using `IDriveScanner`
- update `DirectoryComparerWorker` to construct the comparer
- add end-to-end BDD scenario and unit test
- document new components and tests in the README

## Testing
- `dotnet test --no-build --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_68543e53796483309d63c9bc15b891ce