### PR TITLE
Fix DirectoryComparer and update tests

### DIFF
--- a/MetricsPipeline.Core.Tests/DirectoryComparerTests.cs
+++ b/MetricsPipeline.Core.Tests/DirectoryComparerTests.cs
@@ -15,7 +15,7 @@ public class DirectoryComparerTests
     {
         var scanner = new Mock<IDriveScanner>();
         scanner.Setup(s => s.GetDirectoriesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-               .ReturnsAsync(Array.Empty<string>());
+               .ReturnsAsync(Array.Empty<DirectoryEntry>());
 
         var comparer = new DirectoryComparer(scanner.Object);
 

--- a/MetricsPipeline.Core.Tests/Steps/GoogleDriveScannerSteps.cs
+++ b/MetricsPipeline.Core.Tests/Steps/GoogleDriveScannerSteps.cs
@@ -64,6 +64,7 @@ public class GoogleDriveScannerSteps
     [Then("the shortcut folder name should be returned")]
     public void ThenTheShortcutFolderNameShouldBeReturned()
     {
-        _result.Should().ContainSingle().Which.Should().Be("link");
+        var names = _result!.Select(d => d.Name).ToList();
+        names.Should().ContainSingle().Which.Should().Be("link");
     }
 }

--- a/MetricsPipeline.Core/DirectoryComparer.cs
+++ b/MetricsPipeline.Core/DirectoryComparer.cs
@@ -27,9 +27,9 @@ public sealed class DirectoryComparer : IDirectoryComparer
         var mismatches = new List<MismatchRow>();
 
         var srcDirs = (await _scanner.GetDirectoriesAsync(sourcePath, cancellationToken))
-            .Select(d => Path.GetRelativePath(sourcePath, d));
+            .Select(d => Path.GetRelativePath(sourcePath, d.Name));
         var dstDirs = (await _scanner.GetDirectoriesAsync(destinationPath, cancellationToken))
-            .Select(d => Path.GetRelativePath(destinationPath, d));
+            .Select(d => Path.GetRelativePath(destinationPath, d.Name));
 
         var allDirs = new HashSet<string>(srcDirs, StringComparer.OrdinalIgnoreCase);
         foreach (var d in dstDirs)

--- a/MetricsPipeline.Core/DirectoryScanner.cs
+++ b/MetricsPipeline.Core/DirectoryScanner.cs
@@ -1,8 +1,10 @@
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace MetricsPipeline.Core;
 

--- a/README.md
+++ b/README.md
@@ -208,3 +208,11 @@ HTML summary. Aim for coverage above 80% to catch regressions.
 The BDD suite now includes a scenario checking shortcut resolution when
 `--follow-shortcuts` is supplied.
 
+Additional notes:
+1. `DirectoryComparer` now works with `DirectoryEntry` results so scanners can provide IDs and names separately.
+2. Unit tests may use a simple `FileSystemDriveScanner` stub to expose local folders as `DirectoryEntry` objects.
+3. `DirectoryScanner` requires its dependencies via the constructor, making it easy to inject mocks during testing.
+4. Run `dotnet build` before testing if feature files change so the generated bindings stay in sync.
+5. Use `reportgenerator` to convert the Cobertura file to HTML and confirm coverage visually.
+6. The scanner's concurrency can be tuned by passing a different `maxConcurrency` when constructing `DirectoryScanner`.
+


### PR DESCRIPTION
## Summary
- handle `DirectoryEntry` results in `DirectoryComparer`
- update `DirectoryScanner` using directives
- fix BDD steps and unit tests for new APIs
- document additional notes on using the library

## Testing
- `dotnet build`
- `dotnet test --collect:"XPlat Code Coverage" --no-build --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_68545ca5d3588330a4f0e11e494f6bf1