### PR TITLE
Fix DirectoryScanner tests

### DIFF
--- a/MetricsPipeline.Core.Tests/DirectoryComparerTests.cs
+++ b/MetricsPipeline.Core.Tests/DirectoryComparerTests.cs
@@ -15,7 +15,7 @@ public class DirectoryComparerTests
     {
         var scanner = new Mock<IDriveScanner>();
         scanner.Setup(s => s.GetDirectoriesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-               .ReturnsAsync(Array.Empty<string>());
+               .ReturnsAsync(Array.Empty<DirectoryEntry>());
 
         var comparer = new DirectoryComparer(scanner.Object);
 

--- a/MetricsPipeline.Core.Tests/Steps/GoogleDriveScannerSteps.cs
+++ b/MetricsPipeline.Core.Tests/Steps/GoogleDriveScannerSteps.cs
@@ -64,6 +64,6 @@ public class GoogleDriveScannerSteps
     [Then("the shortcut folder name should be returned")]
     public void ThenTheShortcutFolderNameShouldBeReturned()
     {
-        _result.Should().ContainSingle().Which.Should().Be("link");
+        _result.Should().ContainSingle().Which.Name.Should().Be("link");
     }
 }

--- a/MetricsPipeline.Core/DirectoryComparer.cs
+++ b/MetricsPipeline.Core/DirectoryComparer.cs
@@ -27,9 +27,9 @@ public sealed class DirectoryComparer : IDirectoryComparer
         var mismatches = new List<MismatchRow>();
 
         var srcDirs = (await _scanner.GetDirectoriesAsync(sourcePath, cancellationToken))
-            .Select(d => Path.GetRelativePath(sourcePath, d));
+            .Select(d => d.Name);
         var dstDirs = (await _scanner.GetDirectoriesAsync(destinationPath, cancellationToken))
-            .Select(d => Path.GetRelativePath(destinationPath, d));
+            .Select(d => d.Name);
 
         var allDirs = new HashSet<string>(srcDirs, StringComparer.OrdinalIgnoreCase);
         foreach (var d in dstDirs)

--- a/MetricsPipeline.Core/DirectoryScanner.cs
+++ b/MetricsPipeline.Core/DirectoryScanner.cs
@@ -3,6 +3,8 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
 
 namespace MetricsPipeline.Core;
 


### PR DESCRIPTION
## Summary
- fix DirectoryScanner usings
- update DirectoryComparer to use `DirectoryEntry`
- stub local scanner for DirectoryComparerSteps
- update GoogleDriveScannerSteps assertion
- fix DirectoryComparer unit test for DirectoryEntry

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_68545ca27b5c83308ecc1e6ac26fc3bc