### PR TITLE
Implement env defaults for CLI and add cancellation

### DIFF
--- a/MetricsCli/PipelineRunner.cs
+++ b/MetricsCli/PipelineRunner.cs
@@ -9,18 +9,19 @@ public static class PipelineRunner
         IDriveScanner googleScanner,
         IDriveScanner microsoftScanner,
         Stream output,
-        ILoggerFactory loggerFactory)
+        ILoggerFactory loggerFactory,
+        CancellationToken cancellationToken = default)
     {
-        var gScanner = new DirectoryScanner(googleScanner, loggerFactory.CreateLogger<DirectoryScanner>());
-        var mScanner = new DirectoryScanner(microsoftScanner, loggerFactory.CreateLogger<DirectoryScanner>());
-        var googleCounts = await gScanner.ScanAsync(options.GoogleRoot, options.GoogleRoot);
-        var microsoftCounts = await mScanner.ScanAsync(options.MsRoot, options.MsRoot);
+        var gScanner = new DirectoryScanner(googleScanner, loggerFactory.CreateLogger<DirectoryScanner>(), options.MaxDop);
+        var mScanner = new DirectoryScanner(microsoftScanner, loggerFactory.CreateLogger<DirectoryScanner>(), options.MaxDop);
+        var googleCounts = await gScanner.ScanAsync(options.GoogleRoot, options.GoogleRoot, cancellationToken);
+        var microsoftCounts = await mScanner.ScanAsync(options.MsRoot, options.MsRoot, cancellationToken);
 
         var comparer = new DirectoryCountsComparer();
         var differences = comparer.Compare((IReadOnlyDictionary<string, DirectoryCounts>)googleCounts,
             (IReadOnlyDictionary<string, DirectoryCounts>)microsoftCounts);
         var exporter = new CsvExporter();
-        await exporter.ExportAsync(differences, output);
+        await exporter.ExportAsync(differences, output, cancellationToken);
     }
 }
 

--- a/MetricsPipeline.Core.Tests/Features/CommandLine.feature
+++ b/MetricsPipeline.Core.Tests/Features/CommandLine.feature
@@ -8,6 +8,24 @@ Feature: Command Line
     When I parse the arguments "--ms-root m --google-root g"
     Then the parsed options should contain "cred.json"
 
+  Scenario: root paths from environment
+    Given MS_ROOT is set to "m"
+    And GOOGLE_ROOT is set to "g"
+    And OUTPUT_CSV is set to "out.csv"
+    When I parse the arguments ""
+    Then the options MsRoot should be "m"
+    And the options GoogleRoot should be "g"
+    And the output path should be "out.csv"
+
+  Scenario: max dop from environment
+    Given MS_ROOT is set to "m"
+    And GOOGLE_ROOT is set to "g"
+    And environment variable GOOGLE_AUTH is set to "cred.json"
+    And OUTPUT_CSV is set to "out.csv"
+    And MAX_DOP is set to "8"
+    When I parse the arguments ""
+    Then the max dop should be 8
+
   Scenario: exporting CSV results
     When I run the CLI pipeline
     Then the output should contain a CSV header

--- a/MetricsPipeline.Core.Tests/Steps/CommandLineSteps.cs
+++ b/MetricsPipeline.Core.Tests/Steps/CommandLineSteps.cs
@@ -21,6 +21,30 @@ public class CommandLineSteps
         Environment.SetEnvironmentVariable("GOOGLE_AUTH", path);
     }
 
+    [Given("MS_ROOT is set to \"(.*)\"")]
+    public void GivenMsRoot(string value)
+    {
+        Environment.SetEnvironmentVariable("MS_ROOT", value);
+    }
+
+    [Given("GOOGLE_ROOT is set to \"(.*)\"")]
+    public void GivenGoogleRoot(string value)
+    {
+        Environment.SetEnvironmentVariable("GOOGLE_ROOT", value);
+    }
+
+    [Given("OUTPUT_CSV is set to \"(.*)\"")]
+    public void GivenOutputCsv(string value)
+    {
+        Environment.SetEnvironmentVariable("OUTPUT_CSV", value);
+    }
+
+    [Given("MAX_DOP is set to \"(.*)\"")]
+    public void GivenMaxDop(string value)
+    {
+        Environment.SetEnvironmentVariable("MAX_DOP", value);
+    }
+
     [When("I parse the arguments \"(.*)\"")]
     public void WhenIParse(string args)
     {
@@ -31,6 +55,30 @@ public class CommandLineSteps
     public void ThenOptionsShouldContain(string expected)
     {
         _options!.GoogleAuth.Should().Be(expected);
+    }
+
+    [Then("the options MsRoot should be \"(.*)\"")]
+    public void ThenMsRoot(string expected)
+    {
+        _options!.MsRoot.Should().Be(expected);
+    }
+
+    [Then("the options GoogleRoot should be \"(.*)\"")]
+    public void ThenGoogleRoot(string expected)
+    {
+        _options!.GoogleRoot.Should().Be(expected);
+    }
+
+    [Then("the output path should be \"(.*)\"")]
+    public void ThenOutputPath(string expected)
+    {
+        _options!.Output.Should().Be(expected);
+    }
+
+    [Then("the max dop should be (\\d+)")]
+    public void ThenMaxDop(int expected)
+    {
+        _options!.MaxDop.Should().Be(expected);
     }
 
     [When("I run the CLI pipeline")]

--- a/MetricsPipeline.Core/DirectoryScanner.cs
+++ b/MetricsPipeline.Core/DirectoryScanner.cs
@@ -6,8 +6,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
-using Microsoft.Extensions.Logging;
-
 namespace MetricsPipeline.Core;
 
 /// <summary>

--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ for further processing.
     `dotnet tool install --global dotnet-reportgenerator-globaltool`.
 42. Publish the CLI for reuse with `dotnet publish -c Release MetricsCli`.
 43. Set `MAX_DOP` to control API concurrency without editing the source code.
+44. CLI options now fall back to `MS_ROOT`, `GOOGLE_ROOT`, `OUTPUT_CSV` and
+    `MAX_DOP` when corresponding switches are omitted.
+45. `--max-dop` and `MAX_DOP` also control `DirectoryScanner` concurrency so
+    scanning performance matches your environment.
+46. `PipelineRunner.RunAsync` accepts a `CancellationToken` for graceful
+    termination on Ctrl+C.
+47. New BDD scenarios verify environment variable parsing for these options.
+48. Minor cleanup removed duplicate using directives in `DirectoryScanner`.
 
 
 ## OAuth Configuration


### PR DESCRIPTION
## Summary
- default CLI options to environment variables when switches aren't specified
- propagate CancellationToken through `PipelineRunner`
- remove duplicate using in `DirectoryScanner`
- test CLI environment variable support with new BDD scenarios
- document new behavior and cleanup in README

## Testing
- `dotnet test --collect:"XPlat Code Coverage" --no-build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_68548fdf68ec833095189a7f463fe707