### PR TITLE
Enable pipeline execution via appsettings

### DIFF
--- a/DirectorySyncWorker/DirectorySyncWorker.csproj
+++ b/DirectorySyncWorker/DirectorySyncWorker.csproj
@@ -8,6 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />
+    <PackageReference Include="Azure.Identity" Version="1.10.4" />
+    <PackageReference Include="Microsoft.Graph" Version="5.82.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../MetricsPipeline.Core/MetricsPipeline.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/DirectorySyncWorker/Program.cs
+++ b/DirectorySyncWorker/Program.cs
@@ -1,7 +1,34 @@
 using DirectorySyncWorker;
+using Azure.Identity;
+using Google.Apis.Auth.OAuth2;
+using Google.Apis.Drive.v3;
+using Google.Apis.Services;
+using Microsoft.Graph;
+using MetricsPipeline.Core;
+using MetricsPipeline.Core.Infrastructure.Workers;
+using Microsoft.Extensions.Options;
 
 var builder = Host.CreateApplicationBuilder(args);
-builder.Services.AddHostedService<Worker>();
+
+builder.Services.Configure<PipelineOptions>(builder.Configuration.GetSection("Pipeline"));
+builder.Services.AddSingleton(sp => sp.GetRequiredService<IOptions<PipelineOptions>>().Value);
+builder.Services.AddSingleton<ILoggerFactory>(sp => LoggerFactory.Create(b => b.AddConsole()));
+builder.Services.AddSingleton<GoogleDriveScanner>(sp =>
+{
+    var opts = sp.GetRequiredService<PipelineOptions>();
+    var credential = GoogleCredential.FromFile(opts.GoogleAuth!).CreateScoped(DriveService.Scope.DriveReadonly);
+    var service = new DriveService(new BaseClientService.Initializer { HttpClientInitializer = credential });
+    var logger = sp.GetRequiredService<ILogger<GoogleDriveScanner>>();
+    return new GoogleDriveScanner(service, logger, opts.FollowShortcuts, opts.MaxDop);
+});
+builder.Services.AddSingleton<GraphScanner>(sp =>
+{
+    var opts = sp.GetRequiredService<PipelineOptions>();
+    var client = new GraphServiceClient(new DefaultAzureCredential());
+    var logger = sp.GetRequiredService<ILogger<GraphScanner>>();
+    return new GraphScanner(client, logger, opts.MaxDop);
+});
+builder.Services.AddHostedService<PipelineWorker>();
 
 var host = builder.Build();
 host.Run();

--- a/DirectorySyncWorker/appsettings.Development.json
+++ b/DirectorySyncWorker/appsettings.Development.json
@@ -4,5 +4,13 @@
       "Default": "Information",
       "Microsoft.Hosting.Lifetime": "Information"
     }
+  },
+  "Pipeline": {
+    "MsRoot": "{drive-id}",
+    "GoogleRoot": "{folder-id}",
+    "GoogleAuth": "creds.json",
+    "Output": "mismatches.csv",
+    "MaxDop": 4,
+    "FollowShortcuts": false
   }
 }

--- a/DirectorySyncWorker/appsettings.json
+++ b/DirectorySyncWorker/appsettings.json
@@ -4,5 +4,13 @@
       "Default": "Information",
       "Microsoft.Hosting.Lifetime": "Information"
     }
+  },
+  "Pipeline": {
+    "MsRoot": "{drive-id}",
+    "GoogleRoot": "{folder-id}",
+    "GoogleAuth": "creds.json",
+    "Output": "mismatches.csv",
+    "MaxDop": 4,
+    "FollowShortcuts": false
   }
 }

--- a/MetricsPipeline.Core.Tests/Steps/CommandLineSteps.cs
+++ b/MetricsPipeline.Core.Tests/Steps/CommandLineSteps.cs
@@ -12,7 +12,7 @@ namespace MetricsPipeline.Core.Tests.Steps;
 [Binding]
 public class CommandLineSteps
 {
-    private Options? _options;
+    private PipelineOptions? _options;
     private string? _csv;
 
     [Given("environment variable GOOGLE_AUTH is set to \"(.*)\"")]
@@ -88,7 +88,7 @@ public class CommandLineSteps
         var ms = new CliStubScanner(new Dictionary<string, DirectoryCounts> { ["m"] = new DirectoryCounts(0,1,0) });
         using var stream = new MemoryStream();
         var loggerFactory = LoggerFactory.Create(b => { });
-        var options = new Options("m","g","out.csv","cred.json",1,false);
+        var options = new PipelineOptions("m","g","out.csv","cred.json",1,false);
         await PipelineRunner.RunAsync(options, google, ms, stream, loggerFactory);
         stream.Position = 0;
         using var reader = new StreamReader(stream, Encoding.UTF8, leaveOpen:true);

--- a/MetricsPipeline.Core.Tests/Steps/CsvMismatchSteps.cs
+++ b/MetricsPipeline.Core.Tests/Steps/CsvMismatchSteps.cs
@@ -6,7 +6,6 @@ using FluentAssertions;
 using Moq;
 using Microsoft.Extensions.Logging;
 using Reqnroll;
-using MetricsCli;
 using MetricsPipeline.Core;
 
 namespace MetricsPipeline.Core.Tests.Steps;
@@ -60,7 +59,7 @@ public class CsvMismatchSteps
     [When("the comparison pipeline runs")]
     public async Task WhenTheComparisonPipelineRuns()
     {
-        var options = new Options("m", "g", "out.csv", "cred.json", 1, false);
+        var options = new PipelineOptions("m", "g", "out.csv", "cred.json", 1, false);
         await PipelineRunner.RunAsync(options, _google, _microsoft, _stream, _loggerFactory);
         _stream.Position = 0;
         using var reader = new StreamReader(_stream);

--- a/MetricsPipeline.Core/Infrastructure/Workers/PipelineWorker.cs
+++ b/MetricsPipeline.Core/Infrastructure/Workers/PipelineWorker.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System.IO;
+using MetricsPipeline.Core;
+
+namespace MetricsPipeline.Core.Infrastructure.Workers;
+
+/// <summary>
+/// Runs the comparison pipeline once using the provided options and scanners.
+/// </summary>
+public sealed class PipelineWorker : BackgroundService
+{
+    private readonly IDriveScanner _google;
+    private readonly IDriveScanner _microsoft;
+    private readonly PipelineOptions _options;
+    private readonly ILoggerFactory _loggerFactory;
+
+    public PipelineWorker(GoogleDriveScanner google,
+        GraphScanner microsoft,
+        PipelineOptions options,
+        ILoggerFactory loggerFactory)
+    {
+        _google = google;
+        _microsoft = microsoft;
+        _options = options;
+        _loggerFactory = loggerFactory;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await using var stream = File.Create(_options.Output);
+        await PipelineRunner.RunAsync(_options, _google, _microsoft, stream, _loggerFactory, stoppingToken);
+    }
+}

--- a/MetricsPipeline.Core/PipelineOptions.cs
+++ b/MetricsPipeline.Core/PipelineOptions.cs
@@ -1,0 +1,6 @@
+namespace MetricsPipeline.Core;
+
+/// <summary>
+/// Options controlling the end-to-end pipeline execution.
+/// </summary>
+public record PipelineOptions(string MsRoot, string GoogleRoot, string Output, string? GoogleAuth, int MaxDop = 4, bool FollowShortcuts = false);

--- a/MetricsPipeline.Core/PipelineRunner.cs
+++ b/MetricsPipeline.Core/PipelineRunner.cs
@@ -1,11 +1,10 @@
 using Microsoft.Extensions.Logging;
-using MetricsPipeline.Core;
 
-namespace MetricsCli;
+namespace MetricsPipeline.Core;
 
 public static class PipelineRunner
 {
-    public static async Task RunAsync(Options options,
+    public static async Task RunAsync(PipelineOptions options,
         IDriveScanner googleScanner,
         IDriveScanner microsoftScanner,
         Stream output,

--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ for further processing.
     termination on Ctrl+C.
 47. New BDD scenarios verify environment variable parsing for these options.
 48. Minor cleanup removed duplicate using directives in `DirectoryScanner`.
+49. `PipelineRunner` now lives in the core library so other projects can invoke it.
+50. A `PipelineWorker` executes the entire comparison when configured.
+51. Populate the `Pipeline` section in `appsettings.json` with `MsRoot`, `GoogleRoot`, `GoogleAuth`, `Output` and `MaxDop`.
+52. The worker uses these settings to spin up scanners and export a CSV automatically.
+53. Run `dotnet run --project DirectorySyncWorker` after updating the settings to process both drives end to end.
 
 
 ## OAuth Configuration


### PR DESCRIPTION
## Summary
- move `PipelineRunner` to core for reuse
- add `PipelineOptions` and new `PipelineWorker`
- wire up `DirectorySyncWorker` to run the pipeline from app settings
- adjust CLI and tests to use `PipelineOptions`
- document pipeline worker and configuration steps in README

## Testing
- `dotnet build`
- `dotnet test --no-build --no-restore --collect:"XPlat Code Coverage"`

------
https://chatgpt.com/codex/tasks/task_e_685495d0d10483308e268095a7ff70e3