### PR TITLE
Add missing credentials test and troubleshooting notes

### DIFF
--- a/MetricsCli/Program.cs
+++ b/MetricsCli/Program.cs
@@ -1,3 +1,4 @@
+using System;
 using System.CommandLine;
 using Azure.Identity;
 using Google.Apis.Auth.OAuth2;
@@ -49,6 +50,14 @@ public static class Program
         var def = CreateDefinition();
         def.Command.SetHandler(async (string? mRoot, string? gRoot, string? auth, string outFile, int dop, bool follow) =>
         {
+            if (!EnvironmentValidator.Validate(out var errs))
+            {
+                foreach (var err in errs)
+                {
+                    Console.Error.WriteLine(err);
+                }
+                return;
+            }
             var options = new PipelineOptions(
                 mRoot ?? Environment.GetEnvironmentVariable("MS_ROOT") ?? throw new InvalidOperationException("MS root missing"),
                 gRoot ?? Environment.GetEnvironmentVariable("GOOGLE_ROOT") ?? throw new InvalidOperationException("Google root missing"),

--- a/MetricsPipeline.Core.Tests/AssemblyInfo.cs
+++ b/MetricsPipeline.Core.Tests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/MetricsPipeline.Core.Tests/EnvironmentValidatorTests.cs
+++ b/MetricsPipeline.Core.Tests/EnvironmentValidatorTests.cs
@@ -1,0 +1,122 @@
+using System;
+using System.IO;
+using FluentAssertions;
+using Xunit;
+using MetricsPipeline.Core;
+
+namespace MetricsPipeline.Core.Tests;
+
+public class EnvironmentValidatorTests
+{
+    [Fact]
+    public void Validate_ReturnsTrue_WhenAllVariablesPresent()
+    {
+        using var tmp = new TempFile();
+        var prevMs = Environment.GetEnvironmentVariable("MS_ROOT");
+        var prevG = Environment.GetEnvironmentVariable("GOOGLE_ROOT");
+        var prevAuth = Environment.GetEnvironmentVariable("GOOGLE_AUTH");
+        var prevId = Environment.GetEnvironmentVariable("AZURE_CLIENT_ID");
+        var prevTid = Environment.GetEnvironmentVariable("AZURE_TENANT_ID");
+        var prevSecret = Environment.GetEnvironmentVariable("AZURE_CLIENT_SECRET");
+        try
+        {
+        Environment.SetEnvironmentVariable("MS_ROOT", "m");
+        Environment.SetEnvironmentVariable("GOOGLE_ROOT", "g");
+        File.WriteAllText(tmp.Path, "{}");
+        Environment.SetEnvironmentVariable("GOOGLE_AUTH", tmp.Path);
+        Environment.SetEnvironmentVariable("AZURE_CLIENT_ID", "id");
+        Environment.SetEnvironmentVariable("AZURE_TENANT_ID", "tid");
+        Environment.SetEnvironmentVariable("AZURE_CLIENT_SECRET", "secret");
+
+        EnvironmentValidator.Validate(out var errors).Should().BeTrue();
+        errors.Should().BeEmpty();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("MS_ROOT", prevMs);
+            Environment.SetEnvironmentVariable("GOOGLE_ROOT", prevG);
+            Environment.SetEnvironmentVariable("GOOGLE_AUTH", prevAuth);
+            Environment.SetEnvironmentVariable("AZURE_CLIENT_ID", prevId);
+            Environment.SetEnvironmentVariable("AZURE_TENANT_ID", prevTid);
+            Environment.SetEnvironmentVariable("AZURE_CLIENT_SECRET", prevSecret);
+        }
+    }
+
+    [Fact]
+    public void Validate_ReturnsErrors_WhenVariablesMissing()
+    {
+        var prevMs = Environment.GetEnvironmentVariable("MS_ROOT");
+        var prevG = Environment.GetEnvironmentVariable("GOOGLE_ROOT");
+        var prevAuth = Environment.GetEnvironmentVariable("GOOGLE_AUTH");
+        var prevId = Environment.GetEnvironmentVariable("AZURE_CLIENT_ID");
+        var prevTid = Environment.GetEnvironmentVariable("AZURE_TENANT_ID");
+        var prevSecret = Environment.GetEnvironmentVariable("AZURE_CLIENT_SECRET");
+        try
+        {
+        Environment.SetEnvironmentVariable("MS_ROOT", null);
+        Environment.SetEnvironmentVariable("GOOGLE_ROOT", null);
+        Environment.SetEnvironmentVariable("GOOGLE_AUTH", null);
+        Environment.SetEnvironmentVariable("AZURE_CLIENT_ID", null);
+        Environment.SetEnvironmentVariable("AZURE_TENANT_ID", null);
+        Environment.SetEnvironmentVariable("AZURE_CLIENT_SECRET", null);
+
+        EnvironmentValidator.Validate(out var errors).Should().BeFalse();
+        errors.Should().Contain(e => e.Contains("MS_ROOT"));
+        errors.Should().Contain(e => e.Contains("GOOGLE_ROOT"));
+        errors.Should().Contain(e => e.Contains("GOOGLE_AUTH"));
+        errors.Should().Contain(e => e.Contains("Azure AD"));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("MS_ROOT", prevMs);
+            Environment.SetEnvironmentVariable("GOOGLE_ROOT", prevG);
+            Environment.SetEnvironmentVariable("GOOGLE_AUTH", prevAuth);
+            Environment.SetEnvironmentVariable("AZURE_CLIENT_ID", prevId);
+            Environment.SetEnvironmentVariable("AZURE_TENANT_ID", prevTid);
+            Environment.SetEnvironmentVariable("AZURE_CLIENT_SECRET", prevSecret);
+        }
+    }
+
+    [Fact]
+    public void Validate_Fails_WhenCredentialsFileMissing()
+    {
+        var prevMs = Environment.GetEnvironmentVariable("MS_ROOT");
+        var prevG = Environment.GetEnvironmentVariable("GOOGLE_ROOT");
+        var prevAuth = Environment.GetEnvironmentVariable("GOOGLE_AUTH");
+        var prevId = Environment.GetEnvironmentVariable("AZURE_CLIENT_ID");
+        var prevTid = Environment.GetEnvironmentVariable("AZURE_TENANT_ID");
+        var prevSecret = Environment.GetEnvironmentVariable("AZURE_CLIENT_SECRET");
+        try
+        {
+        Environment.SetEnvironmentVariable("MS_ROOT", "m");
+        Environment.SetEnvironmentVariable("GOOGLE_ROOT", "g");
+        Environment.SetEnvironmentVariable("GOOGLE_AUTH", Path.Combine(Path.GetTempPath(), "missing.json"));
+        Environment.SetEnvironmentVariable("AZURE_CLIENT_ID", "id");
+        Environment.SetEnvironmentVariable("AZURE_TENANT_ID", "tid");
+        Environment.SetEnvironmentVariable("AZURE_CLIENT_SECRET", "secret");
+
+        EnvironmentValidator.Validate(out var errors).Should().BeFalse();
+        errors.Should().Contain(e => e.Contains("Google credentials not found"));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("MS_ROOT", prevMs);
+            Environment.SetEnvironmentVariable("GOOGLE_ROOT", prevG);
+            Environment.SetEnvironmentVariable("GOOGLE_AUTH", prevAuth);
+            Environment.SetEnvironmentVariable("AZURE_CLIENT_ID", prevId);
+            Environment.SetEnvironmentVariable("AZURE_TENANT_ID", prevTid);
+            Environment.SetEnvironmentVariable("AZURE_CLIENT_SECRET", prevSecret);
+        }
+    }
+}
+
+internal sealed class TempFile : IDisposable
+{
+    public string Path { get; } = System.IO.Path.GetTempFileName();
+
+    public void Dispose()
+    {
+        if (File.Exists(Path))
+            File.Delete(Path);
+    }
+}

--- a/MetricsPipeline.Core/EnvironmentValidator.cs
+++ b/MetricsPipeline.Core/EnvironmentValidator.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace MetricsPipeline.Core;
+
+/// <summary>
+/// Validates that required environment variables and credentials exist before running the pipeline.
+/// </summary>
+public static class EnvironmentValidator
+{
+    /// <summary>
+    /// Checks environment variables used by the scanners and collects error messages.
+    /// </summary>
+    /// <param name="errors">Populated with error descriptions when validation fails.</param>
+    /// <returns><c>true</c> when the environment is correctly configured.</returns>
+    public static bool Validate(out List<string> errors)
+    {
+        errors = new List<string>();
+
+        var msRoot = Environment.GetEnvironmentVariable("MS_ROOT");
+        if (string.IsNullOrWhiteSpace(msRoot))
+            errors.Add("MS_ROOT is not set.");
+
+        var googleRoot = Environment.GetEnvironmentVariable("GOOGLE_ROOT");
+        if (string.IsNullOrWhiteSpace(googleRoot))
+            errors.Add("GOOGLE_ROOT is not set.");
+
+        var auth = Environment.GetEnvironmentVariable("GOOGLE_AUTH");
+        if (string.IsNullOrWhiteSpace(auth))
+        {
+            errors.Add("GOOGLE_AUTH is not set.");
+        }
+        else if (!File.Exists(auth))
+        {
+            errors.Add($"Google credentials not found: {auth}");
+        }
+
+        var clientId = Environment.GetEnvironmentVariable("AZURE_CLIENT_ID");
+        var tenantId = Environment.GetEnvironmentVariable("AZURE_TENANT_ID");
+        var secret = Environment.GetEnvironmentVariable("AZURE_CLIENT_SECRET");
+        if (string.IsNullOrWhiteSpace(clientId) || string.IsNullOrWhiteSpace(tenantId) || string.IsNullOrWhiteSpace(secret))
+            errors.Add("Azure AD client credentials are missing.");
+
+        return errors.Count == 0;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -119,6 +119,24 @@ dotnet test
 56. Mount your `appsettings.json` when running in Docker so the worker picks up the correct pipeline configuration.
 57. Remember to pass `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1` in container environments to silence locale warnings.
 58. If you encounter a `MissingMethodException` for `PipelineOptions`, clean and rebuild the solution to ensure the latest binaries are used.
+59. `EnvironmentValidator` checks that required environment variables are present before any scans run.
+60. `MetricsCli` prints clear errors when `MS_ROOT`, `GOOGLE_ROOT` or `GOOGLE_AUTH` are missing.
+61. The validator confirms the Google credentials file exists and reports the path when it does not.
+62. Azure authentication requires `AZURE_CLIENT_ID`, `AZURE_TENANT_ID` and `AZURE_CLIENT_SECRET`.
+63. The CLI exits early if validation fails so you can fix the configuration and retry.
+64. A missing credentials file triggers "Google credentials not found"; ensure the path in `GOOGLE_AUTH` is correct.
+65. If Google APIs return a 403 error, confirm the service account has access to the target Drive or folder.
+66. Graph requests failing with 403 usually mean `Files.Read.All` or `Sites.Read.All` consent was not granted.
+67. Azure-related validation errors indicate one of `AZURE_CLIENT_ID`, `AZURE_TENANT_ID` or `AZURE_CLIENT_SECRET` is unset.
+68. Use `--google-root root` to scan your own My Drive; for a Shared Drive supply its root ID instead.
+```csharp
+if (!EnvironmentValidator.Validate(out var errors))
+{
+    foreach (var e in errors)
+        Console.Error.WriteLine(e);
+    return;
+}
+```
 Example `appsettings.json` configuration:
 ```json
 {


### PR DESCRIPTION
## Summary
- add AssemblyInfo to disable test parallelization
- restore environment variables in `EnvironmentValidatorTests`
- add failing credentials test case
- expand README troubleshooting section with guidance for several errors

## Testing
- `~/.dotnet/dotnet test --no-build --no-restore`
- `~/.dotnet/dotnet test --collect:"XPlat Code Coverage"`


------
https://chatgpt.com/codex/tasks/task_e_68559591e47483308ba5e2887c08db41